### PR TITLE
Issue30revision

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -168,9 +168,10 @@ public final class Constants {
 
     public static final Translation2d fieldSize = new Translation2d(16.54, 8.21);
 
-    public static final String LIMELIGHT3_NAME_STRING = "limelight";
-    public static final String LIMELIGHT2_NAME_STRING = "Limelight_2";
-
+    public static final String[] cameraNames = {
+      "Bottom_Right_Cam", //Top right USB
+      "Right_Ardu_Cam" //Bottom right usb
+    };
     public static final Pose2d SPEAKER_POSE2D_BLUE =
         new Pose2d(new Translation2d(-.0381, 5.547868), new Rotation2d(0));
     public static final Pose2d SPEAKER_POSE2D_RED =

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -748,7 +748,7 @@ public final class Constants {
     public static final int elevatorEncoderID = 1;
 
     public static final double elevatorKp = 2;
-    public static final double elevatorKi = 0.05;
+    public static final double elevatorKi = 0.5;
     public static final double elevatorKd = 0.0;
     public static final double elevatorKg = 0.23; // Tune this first
     // carret in the middle, if it stil move up, lower it until it holds it in position

--- a/src/main/java/frc/robot/PhotonVisionCalculations.java
+++ b/src/main/java/frc/robot/PhotonVisionCalculations.java
@@ -1,10 +1,11 @@
 package frc.robot;
 
+import frc.robot.Constants.VisionConstants;
 import frc.robot.subsystems.PhotonVisionSubsystem;
 
 /** Add your docs here. */
 public class PhotonVisionCalculations {
-  private static PhotonVisionSubsystem s_Photon = PhotonVisionSubsystem.getInstance();
+  private static PhotonVisionSubsystem s_Photon = PhotonVisionSubsystem.getInstance(VisionConstants.cameraNames);
 
   public PhotonVisionCalculations() {}
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -29,7 +29,7 @@ public class Robot extends TimedRobot {
 
   public static final CTREConfigs ctreConfigs = new CTREConfigs();
 
-  private final PhotonVisionSubsystem vision = PhotonVisionSubsystem.getInstance();
+  private final PhotonVisionSubsystem vision = PhotonVisionSubsystem.getInstance(VisionConstants.cameraNames);
 
   private final RobotContainer m_robotContainer;
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -193,7 +193,7 @@ public class RobotContainer {
         .rightTrigger(.75)
         .whileTrue(
             new photonAlignCmd(
-                0, s_Swerve, VisionConstants.rightReefX, VisionConstants.rightReefY));
+                1, s_Swerve, VisionConstants.rightReefX, VisionConstants.rightReefY));
     m_driverController
         .b()
         .whileTrue(

--- a/src/main/java/frc/robot/commands/CoralStationCmd.java
+++ b/src/main/java/frc/robot/commands/CoralStationCmd.java
@@ -50,7 +50,7 @@ public class CoralStationCmd extends Command {
     // addRequirements(elevator);
     wrist = V2_SparkMaxWristSubsystem.getInstance();
     elevatorSubsystem = ElevatorSubsystem.getInstance();
-    // s_Photon = PhotonVisionSubsystem.getInstance();
+    // s_Photon = PhotonVisionSubsystem.getInstance(VisionConstants.cameraNames);
     // this.m_Controller = null;
     // this.cameraNum = cameraNum;
     // this.autoDrive = autoDrive;
@@ -63,7 +63,7 @@ public class CoralStationCmd extends Command {
     // addRequirements(elevator);
     wrist = V2_SparkMaxWristSubsystem.getInstance();
     elevatorSubsystem = ElevatorSubsystem.getInstance();
-    // s_Photon = PhotonVisionSubsystem.getInstance();
+    // s_Photon = PhotonVisionSubsystem.getInstance(VisionConstants.cameraNames);
     // this.m_Controller = m_Controller;
     // this.cameraNum = cameraNum;
     addRequirements(wrist, elevatorSubsystem);

--- a/src/main/java/frc/robot/commands/Stage2CMD.java
+++ b/src/main/java/frc/robot/commands/Stage2CMD.java
@@ -61,7 +61,7 @@ public class Stage2CMD extends Command {
       XboxController m_Controller, Trigger leftControl, Trigger rightControl, int cameraNum) {
     elevator = ElevatorSubsystem.getInstance();
     wrist = V2_SparkMaxWristSubsystem.getInstance();
-    s_Photon = PhotonVisionSubsystem.getInstance();
+    s_Photon = PhotonVisionSubsystem.getInstance(VisionConstants.cameraNames);
     // this.s_Swerve = s_Swerve;
     this.leftControl = leftControl;
     this.rightControl = rightControl;
@@ -77,7 +77,7 @@ public class Stage2CMD extends Command {
   public Stage2CMD(int cameraNum, Trigger leftControl, Trigger rightControl) {
     elevator = ElevatorSubsystem.getInstance();
     wrist = V2_SparkMaxWristSubsystem.getInstance();
-    s_Photon = PhotonVisionSubsystem.getInstance();
+    s_Photon = PhotonVisionSubsystem.getInstance(VisionConstants.cameraNames);
 
     this.leftControl = leftControl;
     this.rightControl = rightControl;

--- a/src/main/java/frc/robot/commands/Stage3CMD.java
+++ b/src/main/java/frc/robot/commands/Stage3CMD.java
@@ -60,7 +60,7 @@ public class Stage3CMD extends Command {
       XboxController m_Controller, Trigger leftControl, Trigger rightControl, int cameraNum) {
     elevator = ElevatorSubsystem.getInstance();
     wrist = V2_SparkMaxWristSubsystem.getInstance();
-    s_Photon = PhotonVisionSubsystem.getInstance();
+    s_Photon = PhotonVisionSubsystem.getInstance(VisionConstants.cameraNames);
     this.leftControl = leftControl;
     // this.s_Swerve = s_Swerve;
     this.rightControl = rightControl;
@@ -76,7 +76,7 @@ public class Stage3CMD extends Command {
   public Stage3CMD(int cameraNum, Trigger leftControl, Trigger rightControl) {
     elevator = ElevatorSubsystem.getInstance();
     wrist = V2_SparkMaxWristSubsystem.getInstance();
-    s_Photon = PhotonVisionSubsystem.getInstance();
+    s_Photon = PhotonVisionSubsystem.getInstance(VisionConstants.cameraNames);
 
     this.leftControl = leftControl;
     this.rightControl = rightControl;

--- a/src/main/java/frc/robot/commands/Stage4CMD.java
+++ b/src/main/java/frc/robot/commands/Stage4CMD.java
@@ -62,7 +62,7 @@ public class Stage4CMD extends Command {
       XboxController m_Controller, Trigger leftControl, Trigger rightControl, int cameraNum) {
     elevator = ElevatorSubsystem.getInstance();
     wrist = V2_SparkMaxWristSubsystem.getInstance();
-    s_Photon = PhotonVisionSubsystem.getInstance();
+    s_Photon = PhotonVisionSubsystem.getInstance(VisionConstants.cameraNames);
     this.leftControl = leftControl;
     this.rightControl = rightControl;
     this.m_Controller = m_Controller;
@@ -78,7 +78,7 @@ public class Stage4CMD extends Command {
   public Stage4CMD(int cameraNum, Trigger leftControl, Trigger rightControl) {
     elevator = ElevatorSubsystem.getInstance();
     wrist = V2_SparkMaxWristSubsystem.getInstance();
-    s_Photon = PhotonVisionSubsystem.getInstance();
+    s_Photon = PhotonVisionSubsystem.getInstance(VisionConstants.cameraNames);
 
     this.leftControl = leftControl;
     this.rightControl = rightControl;

--- a/src/main/java/frc/robot/commands/photonAlignCmd.java
+++ b/src/main/java/frc/robot/commands/photonAlignCmd.java
@@ -79,6 +79,10 @@ public class photonAlignCmd extends Command {
     // 1).getFiducialId()] -
     // PhotonVisionCalculations.estimateAdjacent(s_Photon.getBestTarget().get(cameraNum).getFiducialId(), cameraNum);
     VisionConstants.setTagXYHeightAngle();
+
+    //call initPhoton here so that it will declare objects when camera is plugged in while the code is running
+    //call initphoton also so that things will get cleared out if something disconnects
+    s_Photon.initPhoton();
   }
 
   // Called every time the scheduler runs while the command is scheduled.

--- a/src/main/java/frc/robot/commands/photonAlignCmd.java
+++ b/src/main/java/frc/robot/commands/photonAlignCmd.java
@@ -50,7 +50,7 @@ public class photonAlignCmd extends Command {
   /** Creates a new photonAlign. */
   public photonAlignCmd(int cameraNum, Swerve s_Swerve, double xSetpoint, double ySetpoint) {
     // Use addRequirements() here to declare subsystem dependencies.
-    s_Photon = PhotonVisionSubsystem.getInstance();
+    s_Photon = PhotonVisionSubsystem.getInstance(VisionConstants.cameraNames);
     this.s_Swerve = s_Swerve;
     addRequirements(s_Photon, s_Swerve);
     this.cameraNum = cameraNum;
@@ -60,7 +60,7 @@ public class photonAlignCmd extends Command {
 
   // public photonAlignCmd(int cameraNum, Swerve s_Swerve, double offset) {
   //   // Use addRequirements() here to declare subsystem dependencies.
-  //   s_Photon = PhotonVisionSubsystem.getInstance();
+  //   s_Photon = PhotonVisionSubsystem.getInstance(VisionConstants.cameraNames);
   //   this.s_Swerve = s_Swerve;
   //   addRequirements(s_Photon, s_Swerve);
   //   this.cameraNum = cameraNum;
@@ -86,7 +86,11 @@ public class photonAlignCmd extends Command {
   public void execute() {
     System.out.print("Photon vision cmd running");
     s_Photon.updatePhoton();
-    if (!s_Photon.getResults().get(cameraNum).isEmpty()) {
+    if (
+      s_Photon.getResults().containsKey(cameraNum) &&
+      s_Photon.getResults().get(cameraNum) != null  &&
+      !s_Photon.getResults().get(cameraNum).isEmpty()
+      ) {
       List<PhotonTrackedTarget> bestTarget = s_Photon.getBestTargets().get(cameraNum);
       SmartDashboard.putNumber("lockedInNum", lockedFiducialID);
       if (bestTarget != null) {
@@ -125,6 +129,19 @@ public class photonAlignCmd extends Command {
         }
       }
     }
+    else
+    {
+      System.err.println(
+        "Something's wrong with photon," + 
+        "paste this line and search it globally to find it and look at possible errors in the comment"
+        );
+        /*Potential problem
+         * 1. Coprocessor not powered
+         * 2. Camera not connected
+         * 3. Photonvision not seen on networktable
+         */
+        end(true);
+    }
   }
 
   // Called once the command ends or is interrupted.
@@ -138,9 +155,11 @@ public class photonAlignCmd extends Command {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return s_Photon
-        .getResults()
-        .get(cameraNum)
-        .isEmpty(); // if there's no tag automatically stop it from driving
+    return s_Photon.getResults().containsKey(cameraNum) &&
+           s_Photon.getResults().get(cameraNum) != null &&
+           s_Photon
+            .getResults()
+            .get(cameraNum)
+            .isEmpty(); // if there's no tag automatically stop it from driving
   }
 }

--- a/src/main/java/frc/robot/subsystems/PhotonVisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/PhotonVisionSubsystem.java
@@ -43,20 +43,7 @@ public class PhotonVisionSubsystem extends SubsystemBase {
   
   VisionConstants.setTagXYHeightAngle();
   
-  for (int i = 0; i < cameraNames.length; i++) {
-    if (isCameraConnected(cameraNames[i])) {
-      cameras[i] = new PhotonCamera(cameraNames[i]);
-      System.out.println("Photon camera initialized: " + cameraNames[i]);
-      cameras[i].setPipelineIndex(0);
-      NetworkTable camTable = NetworkTableInstance.getDefault().getTable("photonvision/" + cameras[i].getName());
-      NetworkTableEntry heartbeatEntry = camTable.getEntry("heartbeat");
-      lastHeartbeats[i] = (long) heartbeatEntry.getDouble(-1);
-    } else {
-      cameras[i] = null;
-      System.out.println("Photon camera not found: " + cameraNames[i]);
-      lastHeartbeats[i] = -1;
-    }
-  }
+  initPhoton();
     
   results = new HashMap<Integer, List<PhotonPipelineResult>>();
   for (int i = 0; i < cameras.length; i++) {
@@ -74,7 +61,8 @@ public class PhotonVisionSubsystem extends SubsystemBase {
     // This method will be called once per scheduler run
   }
 
-  public void updatePhoton() {
+  public void initPhoton()
+  {
     for (int i = 0; i < cameraNames.length; i++) {
       if (isCameraConnected(cameraNames[i])) {
         cameras[i] = new PhotonCamera(cameraNames[i]);
@@ -89,10 +77,14 @@ public class PhotonVisionSubsystem extends SubsystemBase {
         lastHeartbeats[i] = -1;
       }
     }
+  }
+
+  public void updatePhoton() {
     for (int i = 0; i < cameras.length; i++) {
       if (cameras[i] == null) {
         results.put(i, null);
         bestTarget.put(i, new ArrayList<>());
+        System.err.println(cameraNames[i] + " isNull");
         continue;
       }
 
@@ -102,6 +94,7 @@ public class PhotonVisionSubsystem extends SubsystemBase {
       if (!heartbeatEntry.exists()) {
           results.put(i, null);
           bestTarget.put(i, new ArrayList<>());
+          System.err.println(cameraNames[i] + "doesn't have a heartbeat entry");
           continue;
       }
 
@@ -110,23 +103,25 @@ public class PhotonVisionSubsystem extends SubsystemBase {
           // Heartbeat hasn't changed → camera likely stalled or unplugged
           results.put(i, null);
           bestTarget.put(i, new ArrayList<>());
+          System.err.println(cameraNames[i] + "heartbeat stayed the same");
           continue;
       }
 
       lastHeartbeats[i] = currentHeartbeat;
 
       List<PhotonPipelineResult> unreadResults = cameras[i].getAllUnreadResults();
+      // System.out.println(cameraNames[i] + "pipeline updated");
       if (!unreadResults.isEmpty()) {
         results.put(i, unreadResults);
       }
       else
       {
+        System.err.println(cameraNames[i] + "pipeline is empty");
         continue;
       } 
       if (!results.isEmpty()) {
         bestTarget.put(i, results.get(i).get(0).getTargets());
-        // System.out.println("Best Target IS GETTING UPDATED --------------");
-
+        // System.out.println("Best Target IS GETTING UPDATED -------------- for " + cameraNames[i]);
       }
     }
   }

--- a/src/main/java/frc/robot/subsystems/PhotonVisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/PhotonVisionSubsystem.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
@@ -7,6 +8,9 @@ import org.photonvision.PhotonCamera;
 import org.photonvision.targeting.PhotonPipelineResult;
 import org.photonvision.targeting.PhotonTrackedTarget;
 
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.VisionConstants;
@@ -16,11 +20,9 @@ public class PhotonVisionSubsystem extends SubsystemBase {
   // "src\main\deploy\vision\2025-reefscape-andymark.json"
   // public static Path path =
   // Filesystem.getDeployDirectory().toPath().resolve("2025-reefscape-andymark.json");
-  private static PhotonCamera[] cameras = {
-    new PhotonCamera("Bottom_Right_Cam"), // Top Right USB
-    new PhotonCamera("Right_Ardu_Cam") // Bottom Right USB
-    // new PhotonCamera("Left_Ardu_Cam")
-  };
+  private static PhotonCamera[] cameras;
+  private static String[] cameraNames;
+  private final long[] lastHeartbeats;
 
   public static Field2d theFieldCam0 = new Field2d(), theFieldCam1 = new Field2d();
 
@@ -34,22 +36,33 @@ public class PhotonVisionSubsystem extends SubsystemBase {
   private HashMap<Integer, List<PhotonTrackedTarget>> bestTarget;
 
   /** Creates a new PhotonVisionSubsystem. */
-  public PhotonVisionSubsystem() {
-    for (int i = 0; i < cameras.length; i++) {
+  public PhotonVisionSubsystem(String[] cameraNames) {
+    cameras = new PhotonCamera[cameraNames.length];
+    lastHeartbeats = new long[cameraNames.length];
+    this.cameraNames = cameraNames;
+  
+  VisionConstants.setTagXYHeightAngle();
+  
+  for (int i = 0; i < cameraNames.length; i++) {
+    if (isCameraConnected(cameraNames[i])) {
+      cameras[i] = new PhotonCamera(cameraNames[i]);
+      System.out.println("Photon camera initialized: " + cameraNames[i]);
       cameras[i].setPipelineIndex(0);
+      NetworkTable camTable = NetworkTableInstance.getDefault().getTable("photonvision/" + cameras[i].getName());
+      NetworkTableEntry heartbeatEntry = camTable.getEntry("heartbeat");
+      lastHeartbeats[i] = (long) heartbeatEntry.getDouble(-1);
+    } else {
+      cameras[i] = null;
+      System.out.println("Photon camera not found: " + cameraNames[i]);
+      lastHeartbeats[i] = -1;
     }
-
-    VisionConstants.setTagXYHeightAngle();
-
-    results = new HashMap<Integer, List<PhotonPipelineResult>>();
-    for (int i = 0; i < cameras.length; i++) {
-      // if (!cameras[i].getAllUnreadResults().isEmpty()) {
-      //   results.put(i, cameras[i].getAllUnreadResults());
-      // } else {
-      results.put(i, null);
-      // }
-    }
-
+  }
+    
+  results = new HashMap<Integer, List<PhotonPipelineResult>>();
+  for (int i = 0; i < cameras.length; i++) {
+          results.put(i, null);
+        }
+        
     bestTarget = new HashMap<Integer, List<PhotonTrackedTarget>>();
     for (int i = 0; i < cameras.length; i++) {
       bestTarget.put(i, null);
@@ -62,14 +75,53 @@ public class PhotonVisionSubsystem extends SubsystemBase {
   }
 
   public void updatePhoton() {
+    for (int i = 0; i < cameraNames.length; i++) {
+      if (isCameraConnected(cameraNames[i])) {
+        cameras[i] = new PhotonCamera(cameraNames[i]);
+        System.out.println("Photon camera initialized: " + cameraNames[i]);
+        cameras[i].setPipelineIndex(0);
+        NetworkTable camTable = NetworkTableInstance.getDefault().getTable("photonvision/" + cameras[i].getName());
+        NetworkTableEntry heartbeatEntry = camTable.getEntry("heartbeat");
+        lastHeartbeats[i] = (long) heartbeatEntry.getDouble(-1);
+      } else {
+        cameras[i] = null;
+        System.out.println("Photon camera not found: " + cameraNames[i]);
+        lastHeartbeats[i] = -1;
+      }
+    }
     for (int i = 0; i < cameras.length; i++) {
+      if (cameras[i] == null) {
+        results.put(i, null);
+        bestTarget.put(i, new ArrayList<>());
+        continue;
+      }
+
+      NetworkTable camTable = NetworkTableInstance.getDefault().getTable("photonvision/" + cameras[i].getName());
+      NetworkTableEntry heartbeatEntry = camTable.getEntry("heartbeat");
+
+      if (!heartbeatEntry.exists()) {
+          results.put(i, null);
+          bestTarget.put(i, new ArrayList<>());
+          continue;
+      }
+
+      long currentHeartbeat = (long) heartbeatEntry.getDouble(-1);
+      if (currentHeartbeat == lastHeartbeats[i]) {
+          // Heartbeat hasn't changed → camera likely stalled or unplugged
+          results.put(i, null);
+          bestTarget.put(i, new ArrayList<>());
+          continue;
+      }
+
+      lastHeartbeats[i] = currentHeartbeat;
+
       List<PhotonPipelineResult> unreadResults = cameras[i].getAllUnreadResults();
       if (!unreadResults.isEmpty()) {
         results.put(i, unreadResults);
       }
       else
       {
-        return;
+        continue;
       } 
       if (!results.isEmpty()) {
         bestTarget.put(i, results.get(i).get(0).getTargets());
@@ -78,6 +130,11 @@ public class PhotonVisionSubsystem extends SubsystemBase {
       }
     }
   }
+
+  private boolean isCameraConnected(String cameraName) {
+        NetworkTable table = NetworkTableInstance.getDefault().getTable("photonvision/" + cameraName);
+        return table.getKeys().size() > 0;
+    }
 
   // public static void updateCamerasPoseEstimation(Swerve s_Swerve, SwerveDrivePoseEstimator
   // poseEstimator, double
@@ -180,9 +237,9 @@ public class PhotonVisionSubsystem extends SubsystemBase {
     return bestTarget;
   }
 
-  public static synchronized PhotonVisionSubsystem getInstance() {
+  public static synchronized PhotonVisionSubsystem getInstance(String[] cameraNames) {
     if (INSTANCE == null) {
-      INSTANCE = new PhotonVisionSubsystem();
+      INSTANCE = new PhotonVisionSubsystem(cameraNames);
     }
     return INSTANCE;
   }

--- a/src/main/java/frc/robot/subsystems/PhotonVisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/PhotonVisionSubsystem.java
@@ -67,6 +67,10 @@ public class PhotonVisionSubsystem extends SubsystemBase {
       if (!unreadResults.isEmpty()) {
         results.put(i, unreadResults);
       }
+      else
+      {
+        return;
+      } 
       if (!results.isEmpty()) {
         bestTarget.put(i, results.get(i).get(0).getTargets());
         // System.out.println("Best Target IS GETTING UPDATED --------------");

--- a/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/Swerve.java
@@ -8,6 +8,7 @@ import frc.robot.Constants;
 // import frc.robot.LimelightHelpers;
 import frc.robot.SwerveModule;
 import frc.robot.Constants.SwerveConstants;
+import frc.robot.Constants.VisionConstants;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 // import edu.wpi.first.math.kinematics.SwerveDriveOdometry;
@@ -126,7 +127,7 @@ public class Swerve extends SubsystemBase {
   // private double targetYaw;
   // private double targetPitch;
 
-  PhotonVisionSubsystem s_Photon = PhotonVisionSubsystem.getInstance();
+  PhotonVisionSubsystem s_Photon = PhotonVisionSubsystem.getInstance(VisionConstants.cameraNames);
 
   PhotonPipelineResult result;
 


### PR DESCRIPTION
Totally resolved the issue by getting the networktable values every time to check if there is specified camera on the network table. If multiple cameras but one got unplug & the coprocessor is working, it still updates the value for the other camera and the command will automatically end itself when it's trying to call the unplugged camera. Also it will not do anything when the whole processor/any camera is unplugged and will not keep the value if it saw an apriltag before because we are checking/initializing if there's as many photon cameras as we expected to show up every time we run the command.